### PR TITLE
Fixes broken README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ export default class extends TurboMountController {
   onChange = (color) => {
     // same as this.propsValue = { ...this.propsValue, color };
     // but skips the rerendering of the component:
-    this.setComponentProps({ ...this.propsValue, color })
+    this.setComponentProps({ ...this.propsValue, color });
   };
 }
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ export default class extends TurboMountController {
   onChange = (color) => {
     // same as this.propsValue = { ...this.propsValue, color };
     // but skips the rerendering of the component:
-    this.componentProps = { ...this.propsValue, color };
+    this.setComponentProps({ ...this.propsValue, color })
   };
 }
 ```


### PR DESCRIPTION
When trying to extend `TurboMountController` based on the README, I found this error:

![Screenshot 2024-06-15 at 15 42 23](https://github.com/skryukov/turbo-mount/assets/62041079/41fd7916-bc3f-44a8-885f-728e5df898c9)

This PR fixes the README.md example.
