### PR TITLE
ESBuild support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Add `registerComponents` helper for ESBuild. ([@skryukov])
+
 ### Fixed
 
 - Fix entrypoint issue in the install generator. ([@skryukov])

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
   - [View Helpers](#view-helpers)
   - [Supported Frameworks](#supported-frameworks)
   - [Custom Controllers](#custom-controllers)
-  - [Vite Integration](#vite-integration)
+  - [Auto-Loading Components](#auto-loading-components)
+    - [Vite Integration](#vite-integration)
+    - [ESBuild Integration](#esbuild-integration)
   - [Mount Target](#mount-target)
 - [License](#license)
 
@@ -161,24 +163,50 @@ import HexColorPickerController from "controllers/turbo_mount/hex_color_picker_c
 registerComponent(turboMount, "HexColorPicker", HexColorPicker, HexColorPickerController);
 ```
 
-### Vite Integration
+### Auto-Loading Components
 
-`TurboMount` includes a `registerComponents` function that automates the loading of components (requires the `stimulus-vite-helpers` package). It also accepts an optional `controllers` property to autoload customized controllers:
+`TurboMount` includes a `registerComponents` functions that automates the loading of components. `registerComponents` also accepts an optional `controllers` property to autoload customized controllers.
+
+The `registerComponents` helpers search for controllers in the following paths:
+- `controllers/turbo-mount/${controllerName}`
+- `controllers/turbo-mount-${controllerName}`
+
+#### Vite Integration
+
+Vite helper requires the `stimulus-vite-helpers` package to load components and controllers. Here's how to set it up:
+
+```bash
+npm install stimulus-vite-helpers
+```
+
+Then use the `registerComponents` helper to autoload components and controllers:
 
 ```js
-import { TurboMount } from "turbo-mount/react";
-import { registerComponents } from "turbo-mount/registerComponents/react";
+import plugin, { TurboMount } from "turbo-mount/react";
+import { registerComponents } from "turbo-mount/registerComponents/vite";
 
 const controllers = import.meta.glob("./**/*_controller.js", { eager: true });
 const components = import.meta.glob("/components/**/*.jsx", { eager: true });
 
 const turboMount = new TurboMount();
-registerComponents({ turboMount, components, controllers });
+registerComponents({ plugin, turboMount, components, controllers });
 ```
 
-The `registerComponents` helper searches for controllers in the following paths:
-- `controllers/turbo-mount/${controllerName}`
-- `controllers/turbo-mount-${controllerName}`
+#### ESBuild Integration
+
+ESBuild helper requires the `esbuild-rails` package to load components and controllers. Read the [ESBuild Rails README](https://github.com/excid3/esbuild-rails) for more information on how to set it up.
+
+```js
+import plugin, { TurboMount } from "turbo-mount/react";
+import { registerComponents } from "turbo-mount/registerComponents/esbuild";
+
+const turboMount = new TurboMount();
+
+import controllers from "./controllers/**/*_controller.js";
+import components from "./components/**/*.jsx";
+
+registerComponents({ plugin, turboMount, components, controllers });
+```
 
 ### Mount Target
 

--- a/packages/turbo-mount/package.json
+++ b/packages/turbo-mount/package.json
@@ -28,6 +28,8 @@
     "./react": "./dist/plugins/react.js",
     "./svelte": "./dist/plugins/svelte.js",
     "./vue": "./dist/plugins/vue.js",
+    "./registerComponents/esbuild": "./dist/registerComponents/esbuild.js",
+    "./registerComponents/vite": "./dist/registerComponents/vite.js",
     "./registerComponents/react": "./dist/registerComponents/react.js",
     "./registerComponents/svelte": "./dist/registerComponents/svelte.js",
     "./registerComponents/vue": "./dist/registerComponents/vue.js",

--- a/packages/turbo-mount/rollup.config.js
+++ b/packages/turbo-mount/rollup.config.js
@@ -45,6 +45,12 @@ entrypoints.unshift({
 }, {
   input: path.join("src", "registerComponents.ts"),
   output: path.join("dist", "registerComponents.js")
+}, {
+  input: path.join("src", "registerComponents/vite.ts"),
+  output: path.join("dist", "registerComponents/vite.js")
+}, {
+  input: path.join("src", "registerComponents/esbuild.ts"),
+  output: path.join("dist", "registerComponents/esbuild.js")
 })
 
 const config = entrypoints.flatMap(({input, output}) => (

--- a/packages/turbo-mount/src/index.ts
+++ b/packages/turbo-mount/src/index.ts
@@ -1,2 +1,3 @@
 export { TurboMountController } from "./turbo-mount-controller";
 export * from "./turbo-mount";
+export * from "./registerComponentsBase";

--- a/packages/turbo-mount/src/registerComponents.ts
+++ b/packages/turbo-mount/src/registerComponents.ts
@@ -1,38 +1,11 @@
-import { definitionsFromGlob } from "stimulus-vite-helpers";
-import { Definition } from "@hotwired/stimulus";
+import { Plugin } from "turbo-mount";
 
 import {
-  TurboMount,
-  Plugin,
-  registerComponentsBase,
-  ComponentModule,
-} from "turbo-mount";
-
-type RegisterComponentsProps<T> = {
-  plugin: Plugin<T>;
-  turboMount: TurboMount;
-  components: Record<string, ComponentModule>;
-  controllers?: Record<string, Definition>;
-};
-
-export const registerComponents = <T>({
-  plugin,
-  turboMount,
-  components,
-  controllers,
-}: RegisterComponentsProps<T>) => {
-  return registerComponentsBase({
-    plugin,
-    turboMount,
-    components: Object.entries(components).map(([filename, module]) => ({
-      filename,
-      module,
-    })),
-    controllers: controllers ? definitionsFromGlob(controllers) : [],
-  });
-};
+  registerComponents,
+  RegisterComponentsViteProps,
+} from "./registerComponents/vite";
 
 export const buildRegisterComponentsFunction = <T>(plugin: Plugin<T>) => {
-  return (props: Omit<RegisterComponentsProps<T>, "plugin">) =>
+  return (props: Omit<RegisterComponentsViteProps<T>, "plugin">) =>
     registerComponents({ plugin, ...props });
 };

--- a/packages/turbo-mount/src/registerComponents/esbuild.ts
+++ b/packages/turbo-mount/src/registerComponents/esbuild.ts
@@ -1,0 +1,45 @@
+import {
+  registerComponentsBase,
+  Plugin,
+  TurboMount,
+  ComponentModule,
+} from "turbo-mount";
+
+export type EsbuildRailsDefinition = {
+  name: string;
+  module: ComponentModule;
+  filename: string;
+};
+
+export type RegisterComponentsEsbuildProps<T> = {
+  plugin: Plugin<T>;
+  turboMount: TurboMount;
+  components: EsbuildRailsDefinition[];
+  controllers?: EsbuildRailsDefinition[];
+};
+
+const registerComponents = <T>({
+  plugin,
+  turboMount,
+  components,
+  controllers,
+}: RegisterComponentsEsbuildProps<T>) => {
+  const mappedControllers = controllers
+    ? controllers.map((controller) => {
+        return {
+          identifier: controller.name,
+          controllerConstructor:
+            controller.module?.default || controller.module,
+        };
+      })
+    : [];
+
+  return registerComponentsBase({
+    plugin,
+    turboMount,
+    components,
+    controllers: mappedControllers,
+  });
+};
+
+export { registerComponents };

--- a/packages/turbo-mount/src/registerComponents/vite.ts
+++ b/packages/turbo-mount/src/registerComponents/vite.ts
@@ -1,0 +1,33 @@
+import { definitionsFromGlob } from "stimulus-vite-helpers";
+import { Definition } from "@hotwired/stimulus";
+
+import {
+  TurboMount,
+  Plugin,
+  registerComponentsBase,
+  ComponentModule,
+} from "turbo-mount";
+
+export type RegisterComponentsViteProps<T> = {
+  plugin: Plugin<T>;
+  turboMount: TurboMount;
+  components: Record<string, ComponentModule>;
+  controllers?: Record<string, Definition>;
+};
+
+export const registerComponents = <T>({
+  plugin,
+  turboMount,
+  components,
+  controllers,
+}: RegisterComponentsViteProps<T>) => {
+  return registerComponentsBase({
+    plugin,
+    turboMount,
+    components: Object.entries(components).map(([filename, module]) => ({
+      filename,
+      module,
+    })),
+    controllers: controllers ? definitionsFromGlob(controllers) : [],
+  });
+};

--- a/packages/turbo-mount/src/registerComponentsBase.ts
+++ b/packages/turbo-mount/src/registerComponentsBase.ts
@@ -1,0 +1,57 @@
+import { Definition } from "@hotwired/stimulus";
+
+import { TurboMount, Plugin } from "./turbo-mount";
+import { camelToKebabCase } from "./helpers";
+
+export type ComponentModule = { default: never } | never;
+
+type ComponentDefinition = {
+  filename: string;
+  module: ComponentModule;
+};
+
+type RegisterComponentsProps<T> = {
+  plugin: Plugin<T>;
+  turboMount: TurboMount;
+  components: ComponentDefinition[];
+  controllers?: Definition[];
+};
+
+const identifierNames = (name: string) => {
+  const controllerName = camelToKebabCase(name);
+
+  return [`turbo-mount--${controllerName}`, `turbo-mount-${controllerName}`];
+};
+
+export const registerComponentsBase = <T>({
+  plugin,
+  turboMount,
+  components,
+  controllers,
+}: RegisterComponentsProps<T>) => {
+  const controllerModules = controllers ?? [];
+
+  for (const { module, filename } of components) {
+    const name = filename
+      .replace(/\.\w*$/, "")
+      .replace(/^[./]*components\//, "");
+
+    const identifiers = identifierNames(name);
+
+    const controller = controllerModules.find(({ identifier }) =>
+      identifiers.includes(identifier),
+    );
+    const component = module.default ?? module;
+
+    if (controller) {
+      turboMount.register(
+        plugin,
+        name,
+        component,
+        controller.controllerConstructor,
+      );
+    } else {
+      turboMount.register(plugin, name, component);
+    }
+  }
+};


### PR DESCRIPTION
This PR extracts the `registerComponentsBase` function to simplify the process of writing auto-loading adapters. It also introduces a `registerComponents` function for ESBuild and extracts the Vite `registerComponents` function to a separate export.

Note: We will likely deprecate the usage of `turbo-mount/registerComponents/react` and `turbo-mount/registerComponents` in favor of `turbo-mount/registerComponents/vite` in upcoming releases.