### PR TITLE
fix: support subdirs for components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Added
+
+- Support components in nested directories. ([@skryukov])
+- Support pnpm build tool. ([@jkogara])
+
 ## [0.3.2] - 2024-06-24
 
 ### Fixed
@@ -65,6 +70,7 @@ and this project adheres to [Semantic Versioning].
 
 - Initial implementation. ([@skryukov])
 
+[@jkogara]: https://github.com/jkogara
 [@skryukov]: https://github.com/skryukov
 
 [Unreleased]: https://github.com/skryukov/turbo-mount/compare/v0.3.2...HEAD

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/turbo-mount.svg)](https://rubygems.org/gems/turbo-mount)
 
-`TurboMount` is a simple library that allows you to add highly interactive components from React, Vue, Svelte, and other gframeworks to your Hotwire application.
+`TurboMount` is a simple library that allows you to add highly interactive components from React, Vue, Svelte, and other frameworks to your Hotwire application.
 
 ### Learn more
 
@@ -21,6 +21,7 @@
   - [Supported Frameworks](#supported-frameworks)
   - [Custom Controllers](#custom-controllers)
   - [Auto-Loading Components](#auto-loading-components)
+    - [Components in Nested Directories](#components-in-nested-directories)
     - [Vite Integration](#vite-integration)
     - [ESBuild Integration](#esbuild-integration)
   - [Mount Target](#mount-target)
@@ -184,6 +185,28 @@ registerComponent(turboMount, "HexColorPicker", HexColorPicker, HexColorPickerCo
 The `registerComponents` helpers search for controllers in the following paths:
 - `controllers/turbo-mount/${controllerName}`
 - `controllers/turbo-mount-${controllerName}`
+
+#### Components in Nested Directories
+
+Turbo Mount supports components located in nested directories. For example, if you have a component structure like:
+
+```
+components/
+├── Dashboard/
+│ └── WeatherWidget.tsx
+└── ...
+```
+
+You can use the following helper to mount the component:
+
+```erb
+<%= turbo_mount("Dashboard/WeatherWidget") %>
+```
+
+For nested components, controllers are searched in these paths:
+
+- `controllers/turbo_mount/dashboard/weather_widget_controller.js`
+- `controllers/turbo_mount_dashboard__weather_widget_controller.js`
 
 #### Vite Integration
 

--- a/lib/turbo/mount/helpers.rb
+++ b/lib/turbo/mount/helpers.rb
@@ -6,7 +6,7 @@ module Turbo
       def turbo_mount(component_name, props: {}, tag: "div", **attrs, &block)
         raise TypeError, "Component name expected" unless component_name.is_a? String
 
-        controller_name = "turbo-mount-#{component_name.underscore.dasherize}"
+        controller_name = "turbo-mount-#{component_name.underscore.dasherize.gsub("/", "--")}"
         attrs["data-controller"] = controller_name
         prefix = "data-#{controller_name}"
         attrs["#{prefix}-component-value"] = component_name

--- a/packages/turbo-mount/src/registerComponentsBase.ts
+++ b/packages/turbo-mount/src/registerComponentsBase.ts
@@ -18,7 +18,7 @@ type RegisterComponentsProps<T> = {
 };
 
 const identifierNames = (name: string) => {
-  const controllerName = camelToKebabCase(name);
+  const controllerName = camelToKebabCase(name).replace("/", "--");
 
   return [`turbo-mount--${controllerName}`, `turbo-mount-${controllerName}`];
 };

--- a/packages/turbo-mount/src/turbo-mount.ts
+++ b/packages/turbo-mount/src/turbo-mount.ts
@@ -75,7 +75,7 @@ export class TurboMount {
     this.components.set(name, { component, plugin });
 
     if (controller) {
-      const controllerName = `turbo-mount-${camelToKebabCase(name)}`;
+      const controllerName = `turbo-mount-${camelToKebabCase(name).replace("/", "--")}`;
       this.application.register(controllerName, controller);
     }
   }


### PR DESCRIPTION
This PR adds support for components located in nested directories. For example, if you have a component structure like:

```
components/
├── Dashboard/
│ └── WeatherWidget.tsx
└── ...
```

You can use the following helper to mount the component:

```erb
<%= turbo_mount("Dashboard/WeatherWidget") %>
```

For nested components, controllers are searched in these paths:

- `controllers/turbo_mount/dashboard/weather_widget_controller.js`
- `controllers/turbo_mount_dashboard__weather_widget_controller.js`

Fixes #15
