### PR TITLE
Fix: Handle underscores in controller names

### DIFF
--- a/app/assets/javascripts/turbo-mount.js
+++ b/app/assets/javascripts/turbo-mount.js
@@ -80,7 +80,9 @@ class TurboMount {
         }
         this.components.set(name, { component, plugin });
         if (controller) {
-            const controllerName = `turbo-mount-${camelToKebabCase(name).replace("/", "--")}`;
+            const controllerName = `turbo-mount-${camelToKebabCase(name)
+              .replace(/_/g, "-")
+              .replace(/\//g, "--")}`;
             this.application.register(controllerName, controller);
         }
     }
@@ -107,8 +109,10 @@ function buildRegisterFunction(plugin) {
 }
 
 const identifierNames = (name) => {
-    const controllerName = camelToKebabCase(name).replace("/", "--");
-    return [`turbo-mount--${controllerName}`, `turbo-mount-${controllerName}`];
+    const controllerName = camelToKebabCase(name)
+      .replace(/_/g, "-")
+      .replace(/\//g, "--");
+    return [`turbo-mount-${controllerName}`];
 };
 const registerComponentsBase = ({ plugin, turboMount, components, controllers, }) => {
     const controllerModules = controllers ?? [];

--- a/packages/turbo-mount/src/registerComponentsBase.ts
+++ b/packages/turbo-mount/src/registerComponentsBase.ts
@@ -18,7 +18,9 @@ type RegisterComponentsProps<T> = {
 };
 
 const identifierNames = (name: string) => {
-  const controllerName = camelToKebabCase(name).replace("/", "--");
+  const controllerName = camelToKebabCase(name)
+    .replace(/_/g, "-")
+    .replace(/\//g, "--");
 
   return [`turbo-mount--${controllerName}`, `turbo-mount-${controllerName}`];
 };

--- a/packages/turbo-mount/src/turbo-mount.ts
+++ b/packages/turbo-mount/src/turbo-mount.ts
@@ -75,7 +75,9 @@ export class TurboMount {
     this.components.set(name, { component, plugin });
 
     if (controller) {
-      const controllerName = `turbo-mount-${camelToKebabCase(name).replace("/", "--")}`;
+      const controllerName = `turbo-mount-${camelToKebabCase(name)
+        .replace(/_/g, "-")
+        .replace(/\//g, "--")}`;
       this.application.register(controllerName, controller);
     }
   }


### PR DESCRIPTION
Previously, `camelToKebabCase(name).replace("/", "--")` did not account for underscores in component names or deep nested components.

This caused misaligned controller names when registering components like `some_component`, which would incorrectly retain the underscore.

This PR:
- Replaces underscores (`_`) with dashes (`-`)
- Globally applies the slash-to-double-dash transformation (`/` → `--`)

Not sure if the minified version comes from a build step, so didn't bother changing there. 

Fixes #25 