### PR TITLE
fix(README): bind `this` for onChange handler in TurboMountController

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ export default class extends TurboMountController {
   get componentProps() {
     return {
       ...this.propsValue,
-      onChange: this.onChange,
+      onChange: this.onChange.bind(this),
     };
   }
 


### PR DESCRIPTION
Ensure that `onChange` callback in controllers maintains the correct context when passed as a prop. Prevents issues with `this` being undefined.