### PR TITLE
Fix turbo morph handling with custom controller names

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ Use the following helpers to mount components in your views:
 This will generate the following HTML:
 
 ```html
-<div data-controller="turbo-mount"
-     data-turbo-mount-component-value="HexColorPicker"
-     data-turbo-mount-props-value="{&quot;color&quot;:&quot;#034&quot;}"
+<div data-controller="turbo-mount-hex-color-picker"
+     data-turbo-mount-hex-color-picker-component-value="HexColorPicker"
+     data-turbo-mount-hex-color-picker-props-value="{&quot;color&quot;:&quot;#034&quot;}"
      class="mb-5">
 </div>
 ```

--- a/app/assets/javascripts/turbo-mount.js
+++ b/app/assets/javascripts/turbo-mount.js
@@ -86,13 +86,11 @@ class TurboMount {
             const { target, detail } = turboMorphEvent;
             const controllerAttr = target.getAttribute("data-controller");
             if (controllerAttr?.includes("turbo-mount")) {
-                // Find the turbo-mount controller name
                 const turboMountController = controllerAttr
                     .split(/\s+/)
                     .find(name => name.startsWith("turbo-mount"));
-                
+
                 if (turboMountController) {
-                    // Generate the props attribute name based on the controller name
                     const propsAttrName = `data-${turboMountController}-props-value`;
                     const newPropsValue = detail.newElement.getAttribute(propsAttrName) || "{}";
                     target.setAttribute(propsAttrName, newPropsValue);

--- a/app/assets/javascripts/turbo-mount.js
+++ b/app/assets/javascripts/turbo-mount.js
@@ -84,10 +84,20 @@ class TurboMount {
         document.addEventListener("turbo:before-morph-element", (event) => {
             const turboMorphEvent = event;
             const { target, detail } = turboMorphEvent;
-            if (target.getAttribute("data-controller")?.includes("turbo-mount")) {
-                target.setAttribute("data-turbo-mount-props-value", detail.newElement.getAttribute("data-turbo-mount-props-value") ||
-                    "{}");
-                event.preventDefault();
+            const controllerAttr = target.getAttribute("data-controller");
+            if (controllerAttr?.includes("turbo-mount")) {
+                // Find the turbo-mount controller name
+                const turboMountController = controllerAttr
+                    .split(/\s+/)
+                    .find(name => name.startsWith("turbo-mount"));
+                
+                if (turboMountController) {
+                    // Generate the props attribute name based on the controller name
+                    const propsAttrName = `data-${turboMountController}-props-value`;
+                    const newPropsValue = detail.newElement.getAttribute(propsAttrName) || "{}";
+                    target.setAttribute(propsAttrName, newPropsValue);
+                    event.preventDefault();
+                }
             }
         });
     }

--- a/packages/turbo-mount/src/turbo-mount.ts
+++ b/packages/turbo-mount/src/turbo-mount.ts
@@ -51,13 +51,21 @@ export class TurboMount {
       const turboMorphEvent = event as unknown as TurboMorphEvent;
       const { target, detail } = turboMorphEvent;
 
-      if (target.getAttribute("data-controller")?.includes("turbo-mount")) {
-        target.setAttribute(
-          "data-turbo-mount-props-value",
-          detail.newElement.getAttribute("data-turbo-mount-props-value") ||
-            "{}",
-        );
-        event.preventDefault();
+      const controllerAttr = target.getAttribute("data-controller");
+      if (controllerAttr?.includes("turbo-mount")) {
+        // Find the turbo-mount controller name
+        const turboMountController = controllerAttr
+          .split(/\s+/)
+          .find((name) => name.startsWith("turbo-mount"));
+
+        if (turboMountController) {
+          // Generate the props attribute name based on the controller name
+          const propsAttrName = `data-${turboMountController}-props-value`;
+          const newPropsValue =
+            detail.newElement.getAttribute(propsAttrName) || "{}";
+          target.setAttribute(propsAttrName, newPropsValue);
+          event.preventDefault();
+        }
       }
     });
   }

--- a/packages/turbo-mount/src/turbo-mount.ts
+++ b/packages/turbo-mount/src/turbo-mount.ts
@@ -53,13 +53,11 @@ export class TurboMount {
 
       const controllerAttr = target.getAttribute("data-controller");
       if (controllerAttr?.includes("turbo-mount")) {
-        // Find the turbo-mount controller name
         const turboMountController = controllerAttr
           .split(/\s+/)
           .find((name) => name.startsWith("turbo-mount"));
 
         if (turboMountController) {
-          // Generate the props attribute name based on the controller name
           const propsAttrName = `data-${turboMountController}-props-value`;
           const newPropsValue =
             detail.newElement.getAttribute(propsAttrName) || "{}";


### PR DESCRIPTION
Because each component gets a custom Stimulus controller name, the data attributes need to be adjusted accordingly. Otherwise the props won't change with a turbo morph response.

I also noticed that the documentation in the README shows the incorrect attribute names (non-customized by the component name).

```html
<div data-controller="turbo-mount"
     data-turbo-mount-component-value="HexColorPicker"
     data-turbo-mount-props-value="{&quot;color&quot;:&quot;#034&quot;}"
     class="mb-5">
</div>
```

I'm not sure what else needs to be done to make this work (minification/etc)? But at least when I add this event handler to my application.js it fixes the issue.